### PR TITLE
fix scanSlashCommands bot config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -643,6 +643,8 @@ client.on("ready", async (c) => {
       await Bot.scanCommands();
       clearInterval(ws);
       console.log("\ncommands scanned successfully");
+    } else {
+      Bot.scanCommands();
     }
     Bot.scanButtons();
     scan = null;


### PR DESCRIPTION
Fix : when scanSlashCommand is set to false the bot doesn't scan slash commands synchronously
